### PR TITLE
Vue3 migration

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,8 +14,11 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - echo Building the Docker image...
-      - docker build -f fullstack.Dockerfile -t $IMAGE_REPO_NAME:$IMAGE_TAG .
+      # Frontend build identity for the "new version, please refresh" prompt:
+      # the spa submodule's commit (submodules are checked out in pre_build).
+      - export APP_COMMIT=$(git -C spa rev-parse --short HEAD)
+      - echo Building the Docker image for spa commit $APP_COMMIT...
+      - docker build -f fullstack.Dockerfile --build-arg APP_COMMIT="$APP_COMMIT" -t $IMAGE_REPO_NAME:$IMAGE_TAG .
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG      
   post_build:
     commands:

--- a/demo.Dockerfile
+++ b/demo.Dockerfile
@@ -5,6 +5,10 @@ RUN yarn global add @quasar/cli
 COPY ./spa .
 # build stage
 FROM develop-stage as build-stage
+# Frontend build identity for the version.json refresh prompt (passed by
+# buildspec.yml as --build-arg APP_COMMIT=<spa commit>).
+ARG APP_COMMIT
+ENV APP_COMMIT=$APP_COMMIT
 RUN yarn
 RUN quasar build
 

--- a/demo.Dockerfile
+++ b/demo.Dockerfile
@@ -1,7 +1,7 @@
-FROM node:lts-alpine3.15 as develop-stage
+FROM node:22-alpine as develop-stage
 WORKDIR /app
 COPY ./spa/package*.json ./
-RUN yarn global add @quasar/cli@1
+RUN yarn global add @quasar/cli
 COPY ./spa .
 # build stage
 FROM develop-stage as build-stage

--- a/deployment/demo/nginx.conf
+++ b/deployment/demo/nginx.conf
@@ -21,6 +21,15 @@ server {
 #    location /server {
 #        proxy_pass http://web;
 #    }
+    # Never serve a stale SPA shell, so a refresh loads the latest build. (Hashed
+    # js/css are immutable and may still be cached.) add_header is all-or-nothing
+    # per location, so the server-level security headers are repeated here.
+    location = /index.html {
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Content-Type-Options "nosniff";
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
     location / {
 #        alias /usr/share/nginx/html/;
         try_files $uri $uri/ /index.html;

--- a/deployment/fullstack/nginx.conf
+++ b/deployment/fullstack/nginx.conf
@@ -19,6 +19,17 @@ server {
         proxy_redirect off;
         rewrite ^/server(/.*)$ $1 break;
     }
+    # The SPA shell must never be served stale, otherwise a "refresh" can reload
+    # the previous build (and the new-version prompt keeps reappearing). Force
+    # revalidation on index.html; the hashed js/css it references are immutable
+    # and may still be cached by the browser. NOTE: add_header is all-or-nothing
+    # per location, so the server-level security headers are repeated here.
+    location = /index.html {
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Content-Type-Options "nosniff";
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/fullstack.Dockerfile
+++ b/fullstack.Dockerfile
@@ -6,6 +6,10 @@ RUN yarn global add @quasar/cli
 COPY ./spa .
 # build stage
 FROM develop-stage as build-stage
+# Frontend build identity for the version.json refresh prompt (passed by
+# buildspec.yml as --build-arg APP_COMMIT=<spa commit>).
+ARG APP_COMMIT
+ENV APP_COMMIT=$APP_COMMIT
 RUN yarn
 RUN quasar build
 

--- a/fullstack.Dockerfile
+++ b/fullstack.Dockerfile
@@ -1,12 +1,11 @@
 # FROM node:lts-alpine3.15 as develop-stage
-FROM node:18-alpine as develop-stage
+FROM node:22-alpine as develop-stage
 WORKDIR /app
 COPY ./spa/package*.json ./
-RUN yarn global add @quasar/cli@1
+RUN yarn global add @quasar/cli
 COPY ./spa .
 # build stage
 FROM develop-stage as build-stage
-ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN yarn
 RUN quasar build
 


### PR DESCRIPTION
build: bump spa submodule to 8e02431 (Vue 3 migration + a11y + version-check)

Advances the recorded spa pointer from 4cf852c to the tested HEAD on the spa

vue3-migration branch, bringing the full Quasar 2 / Vue 3 migration, the

accessibility pass, runtime bug fixes, and the auto-versioned refresh prompt

into the parent repo so the Node-22 build config matches the frontend.